### PR TITLE
ezcurl: allow POST with non-form data

### DIFF
--- a/src/core/Ezcurl_core.ml
+++ b/src/core/Ezcurl_core.ml
@@ -317,6 +317,8 @@ module Make(IO : IO)
     let resp_headers_done = ref false in (* once we get "\r\n" header line *)
     Curl.set_url self url;
     begin match meth with
+      | POST [] when (content <> None) ->
+        Curl.set_post self true
       | POST l -> Curl.set_httppost self l;
       | GET -> Curl.set_httpget self true;
       | PUT -> Curl.set_put self true;


### PR DESCRIPTION
Currently ezcurl always sets CURLOPT_HTTPPOST, but that means it is not able to send a custom body that is not a form (e.g. JSON is quite a common use-case these days).

Add a special case: if the POST params is empty, *and* a 'content' is set, then just set CURLOPT_POST, but not CURLOPT_HTTPPOST.

Example usage:
```
let contents = Ezjsonm.to_string json in
let config = EZ.Config.(verbose true default) in
match EZ.post ~config ~url ~params:[] ~content:(`String contents) () with
```

One example of a server that requires using POST with JSON is `etcd`, and without this change it is impossible to communicate with it by using ezcurl on the 'v3' API.