### PR TITLE
Expose CURLOPT_NOSIGNAL in a global setting

### DIFF
--- a/src/core/ezcurl_core.mli
+++ b/src/core/ezcurl_core.mli
@@ -37,6 +37,9 @@ val delete : t -> unit
 val with_client : ?set_opts:(Curl.t -> unit) -> (t -> 'a) -> 'a
 (** Make a temporary client, call the function with it, then cleanup. *)
 
+val set_no_signal : bool -> unit
+(** Set no_signal default value for each new client instance *)
+
 (** Cookie handling.
 
 @since NEXT_RELEASE *)


### PR DESCRIPTION
When using libcurl with systhreads, the [documentation](https://curl.se/libcurl/c/threadsafe.html) says to set [CURLOPT_NOSIGNAL](https://curl.se/libcurl/c/CURLOPT_NOSIGNAL.html) for every new instance.  Curl (a.k.a. Ocurl) exposes this flag already as `Curl.set_nosignal`.

This proposed change exposes that setting as a global flag so that it's not only possible, but also only needs to be done once to avoid the risk of forgetting.