### PR TITLE
Enhance streaming API control for long-running transfers

### DIFF
--- a/src/core/ezcurl_core.mli
+++ b/src/core/ezcurl_core.mli
@@ -70,6 +70,10 @@ end
    val copy : t -> t
 *)
 
+type curl_error = Curl.curlCode * string
+
+type header = string * string
+
 type response_info = {
   ri_response_time: float;
       (** Total time (in seconds) for the request/response pair.
@@ -86,7 +90,7 @@ val string_of_response_info : response_info -> string
 type 'body response = {
   code: int;
       (** Response code. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Status *)
-  headers: (string * string) list;  (** Response headers *)
+  headers: header list;  (** Response headers *)
   body: 'body;  (** Response body, or [""] *)
   info: response_info;  (** Information about the response *)
 }
@@ -135,11 +139,11 @@ module type S = sig
     ?config:Config.t ->
     ?range:string ->
     ?content:[ `String of string | `Write of bytes -> int -> int ] ->
-    ?headers:(string * string) list ->
+    ?headers:header list ->
     url:string ->
     meth:meth ->
     unit ->
-    (string response, Curl.curlCode * string) result io
+    (string response, curl_error) result io
   (** General purpose HTTP call via cURL.
       @param url the URL to query
       @param meth which method to use (see {!meth})
@@ -173,12 +177,12 @@ module type S = sig
     ?config:Config.t ->
     ?range:string ->
     ?content:[ `String of string | `Write of bytes -> int -> int ] ->
-    ?headers:(string * string) list ->
+    ?headers:header list ->
     url:string ->
     meth:meth ->
     write_into:#input_stream ->
     unit ->
-    (unit response, Curl.curlCode * string) result io
+    (unit response, curl_error) result io
   (** HTTP call via cURL, with a streaming response body.
       The body is given to [write_into] by chunks,
       then [write_into#on_close ()] is called
@@ -190,10 +194,10 @@ module type S = sig
     ?client:t ->
     ?config:Config.t ->
     ?range:string ->
-    ?headers:(string * string) list ->
+    ?headers:header list ->
     url:string ->
     unit ->
-    (string response, Curl.curlCode * string) result io
+    (string response, curl_error) result io
   (** Shortcut for [http ~meth:GET]
       See {!http} for more info.
   *)
@@ -202,11 +206,11 @@ module type S = sig
     ?tries:int ->
     ?client:t ->
     ?config:Config.t ->
-    ?headers:(string * string) list ->
+    ?headers:header list ->
     url:string ->
     content:[ `String of string | `Write of bytes -> int -> int ] ->
     unit ->
-    (string response, Curl.curlCode * string) result io
+    (string response, curl_error) result io
   (** Shortcut for [http ~meth:PUT]
       See {!http} for more info.
   *)
@@ -215,12 +219,12 @@ module type S = sig
     ?tries:int ->
     ?client:t ->
     ?config:Config.t ->
-    ?headers:(string * string) list ->
+    ?headers:header list ->
     ?content:[ `String of string | `Write of bytes -> int -> int ] ->
     params:Curl.curlHTTPPost list ->
     url:string ->
     unit ->
-    (string response, Curl.curlCode * string) result io
+    (string response, curl_error) result io
   (** Shortcut for [http ~meth:(POST params)]
       See {!http} for more info.
   *)

--- a/test/basic_test.ml
+++ b/test/basic_test.ml
@@ -15,11 +15,7 @@ let () =
   let buf = Buffer.create 32 in
   match
     Ezcurl.http_stream ~meth:GET ~url
-      ~write_into:
-        (object
-           method on_input bs i len = Buffer.add_subbytes buf bs i len
-           method on_close () = ()
-        end)
+      ~on_write:(fun bs ~length -> Buffer.add_subbytes buf bs 0 length)
       ()
   with
   | Error (code, msg) ->


### PR DESCRIPTION
This PR refactors the streaming API to grant users finer control over HTTP transfers, particularly for long-running cases. Key changes include:  

- Early access to response metadata by exposes HTTP response code and headers as soon as they’re received (previously only available after the entire body was transferred).  
- Progress monitoring and cancellation, by adding hooks to track transfer progress and interrupt streams programmatically.  

Together, they allow clients to abort transfers early based on metadata (e.g., invalid status code).  

Limitations:
- Malformed headers trigger an immediate failure without giving access to the response code.  
- The `on_respond` callback may receive an early response, but if the transfer fails, the final return will be an error (e.g., because of network issues or when aborted by user).

Alternatively, revisiting the `response` type could better represent the different point of failures:  
```ocaml
type response = {  
  code: int option; (* None if the request failed *)  
  headers: (header list, string) result; (* The headers or an error message if they failed to parse; we could also provide the raw headers, though this is probably a fringe case *)
  body: ('a, curl_error) result;  
}
```  
However, this would break backward compatibility and is still insufficient for  async scenarios, which control flow is actually closer to `(response_code * (headers * body io) io) io`, though it’s syntactically cumbersome.  

While not perfect, this API is strictly more flexible than the current implementation, addressing core pain points for streaming use cases.  
