### PR TITLE
GHA: ocaml-compiler versions as strings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,9 @@ jobs:
           # - macos-latest    # build issues with `ar` (!!!)
           #- windows-latest   # certificate problem
         ocaml-compiler:
-          - 4.08
-          - 4.12
-          - 5.03
+          - '4.08'
+          - '4.14'
+          - '5.3'
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Otherwise, there's a bug where they get interpreted as floats… (it seems the bug doesn't appear here). Using strings is safer in general. Update from OCaml 4.12 to 4.14.